### PR TITLE
CodeFreak RC2 final

### DIFF
--- a/editor/__init__.py
+++ b/editor/__init__.py
@@ -127,15 +127,19 @@ def dirlist(d): # This function heavily based on Martin Skou's connector script 
     noneditable = ["pyc", "pyo"]
     r=['<ul class="jqueryFileTree" style="display: none;">']
     try:
-        for f in sorted(os.listdir(d), key=unicode.lower):
+        sd = sorted(os.listdir(d), key=unicode.lower)
+        # list directories first...
+        for f in sd:
             ff=os.path.join(d,f)
             if os.path.isdir(ff):
                 r.append('<li class="directory collapsed"><img src="/editor/static/images/file-icons/delete.png"><a href="#" rel="%s/">%s</a></li>' % (ff,f))
-            else:
+        # ...then files
+        for f in sd:
+            ff=os.path.join(d,f)
+            if not os.path.isdir(ff):
                 e=os.path.splitext(f)[1][1:] # get .ext and remove dot
                 if (e not in noneditable and f != '__init__.py'):
                     r.append('<li class="file ext_%s"><img src="/editor/static/images/file-icons/delete.png" rel="%s"><a href="#" rel="%s">%s</a></li>' % (e,ff,ff,f))
-        r.append('</ul>')
     except Exception,e:
         r.append('Could not load directory: %s' % str(e))
         print 'Error: ' + str(e)

--- a/editor/static/js/editor-cm.js
+++ b/editor/static/js/editor-cm.js
@@ -152,6 +152,9 @@ function editorSetMode(ext) {
     case 'less':
         mode = 'less';
         break;
+    case 'log':
+        mode = 'log';
+        break;
     default:
         mode = 'text';
     }

--- a/editor/static/js/log.js
+++ b/editor/static/js/log.js
@@ -1,0 +1,32 @@
+CodeMirror.defineMode("log", function() {
+
+  var TOKEN_NAMES = {
+    '*': 'string',
+    '#': 'tag',
+    ' ': 'meta'
+  };
+
+  return {
+    token: function(stream) {
+      var tw_pos = stream.string.search(/[\t ]+?$/);
+
+      if (!stream.sol() || tw_pos === 0) {
+        stream.skipToEnd();
+        return ("error " + (
+          TOKEN_NAMES[stream.string.charAt(0)] || '')).replace(/ $/, '');
+      }
+
+      var token_name = TOKEN_NAMES[stream.peek()] || stream.skipToEnd();
+
+      if (tw_pos === -1) {
+        stream.skipToEnd();
+      } else {
+        stream.pos = tw_pos;
+      }
+
+      return token_name;
+    }
+  };
+});
+
+CodeMirror.defineMIME("text/x-log", "log");

--- a/editor/templates/editor-cm.html
+++ b/editor/templates/editor-cm.html
@@ -33,6 +33,7 @@
     <script src="/editor/static/codemirror2/mode/htmlmixed/htmlmixed.js"></script>
     <script src="/editor/static/codemirror2/mode/python/python.js"></script>
     <script src="/editor/static/codemirror2/mode/less/less.js"></script>
+    <script src="/editor/static/js/log.js"></script>
 
     <script src="/editor/static/codemirror2/lib/util/searchcursor.js"></script>
     <script src="/editor/static/codemirror2/lib/util/search.js"></script>


### PR DESCRIPTION
1. Editor - CodeMirror v2.5
2. Editor - Added CodeMirror theme vibrant-ink
3. Fixed freezing problem with analog-graph
4. Pytronics - added pinMode() and readPins()
5. Updated test-pins to set pin direction
6. Updated email (all config now in smtp_lib)
7. Updated blinkm, ck, motor to Rascal bootstrap style
8. Updated upload-cm/dd (via rascal-1.03) and album to warn when uploads/pictures folder not found
9. Editor - Restored style for MARK in logs
10. Upgraded to bootstrap v2.0.4
11. Added symlink static/log/public.log to /var/log/uwsgi/public.log
12. Updated Reload pytronics to rotate public.log and dispay new log in editor (requires logrotate)
13. Added CodeMirror log mode
14. Editor - New boilerplate for Create Template
15. Editor - display directories before files in file tree
