### PR TITLE
Reduce CodeMirror themes to five

### DIFF
--- a/editor/templates/editor-cm.html
+++ b/editor/templates/editor-cm.html
@@ -8,19 +8,8 @@
     <link rel="stylesheet" type="text/css" href="/editor/static/css/jquery.filetree.css">
     
     <link rel="stylesheet" type="text/css" href="/editor/static/codemirror2/lib/codemirror.css">
-    <link rel="stylesheet" type="text/css" href="/editor/static/codemirror2/theme/ambiance.css">
     <link rel="stylesheet" type="text/css" href="/editor/static/codemirror2/theme/blackboard.css">
-    <link rel="stylesheet" type="text/css" href="/editor/static/codemirror2/theme/cobalt.css">
-    <link rel="stylesheet" type="text/css" href="/editor/static/codemirror2/theme/eclipse.css">
-    <link rel="stylesheet" type="text/css" href="/editor/static/codemirror2/theme/elegant.css">
-    <link rel="stylesheet" type="text/css" href="/editor/static/codemirror2/theme/erlang-dark.css">
-    <link rel="stylesheet" type="text/css" href="/editor/static/codemirror2/theme/lesser-dark.css">
-    <link rel="stylesheet" type="text/css" href="/editor/static/codemirror2/theme/monokai.css">
-    <link rel="stylesheet" type="text/css" href="/editor/static/codemirror2/theme/neat.css">
     <link rel="stylesheet" type="text/css" href="/editor/static/codemirror2/theme/night.css">
-    <link rel="stylesheet" type="text/css" href="/editor/static/codemirror2/theme/rubyblue.css">
-    <link rel="stylesheet" type="text/css" href="/editor/static/codemirror2/theme/vibrant-ink.css">
-    <link rel="stylesheet" type="text/css" href="/editor/static/codemirror2/theme/xq-dark.css">
 
     <link rel="stylesheet/less" type="text/css" href="/editor/static/css/solarized-light-cm.less">
     <link rel="stylesheet/less" type="text/css" href="/editor/static/css/solarized-dark-cm.less">
@@ -223,21 +212,10 @@
                         <div class="controls">
                             <select id="theme" class="span2">
                                 <option selected="selected">default</option>
-                                <option>ambiance</option>
                                 <option>blackboard</option>
-                                <option>cobalt</option>
-                                <option>eclipse</option>
-                                <option>elegant</option>
-                                <option>erlang-dark</option>
-                                <option>lesser-dark</option>
-                                <option>monokai</option>
-                                <option>neat</option>
                                 <option>night</option>
-                                <option>rubyblue</option>
                                 <option>solarized-light</option>
                                 <option>solarized-dark</option>
-                                <option>vibrant-ink</option>
-                                <option>xq-dark</option>
                             </select>
                         </div> <!-- controls -->
                     </div> <!-- control-group -->


### PR DESCRIPTION
Available CodeMirror themes are default, blackboard, night, solarized-light and solarized-dark
Includes fix to lighten night theme purple comments
The default theme is blackboard
CodeMirror version 2.3 (26 Jun 2012)
