### PR TITLE
Updated test-i2c.html to support short write

### DIFF
--- a/public/server.py
+++ b/public/server.py
@@ -52,7 +52,7 @@ def i2cget(addr, reg, mode):
     res = i2cRead(iaddr, ireg, mode)
     print '## i2cget ## {0}'.format(res)
     return str(res)
-    
+
 @public.route('/i2cset/<addr>/<reg>/<val>/<mode>')
 def i2cset(addr, reg, val, mode):
     from pytronics import i2cWrite
@@ -62,7 +62,7 @@ def i2cset(addr, reg, val, mode):
     res = i2cWrite(iaddr, ireg, ival, mode)
     print '## i2cset ## {0}'.format(res)
     return str(res)
-    
+
 @public.route('/i2cscan', methods=['POST'])
 def i2cscan():
     from i2c import scanBus

--- a/public/templates/test-i2c.html
+++ b/public/templates/test-i2c.html
@@ -79,6 +79,10 @@
                                     <input id="size_word" type="radio" name="sizeRadios" value="W" />
                                     Word
                                 </label>
+                                <label class="radio inline">
+                                    <input id="size_short" type="radio" name="sizeRadios" value="C" />
+                                    Short
+                                </label>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
When you select the short radio button, a write translates to /i2cset/chip/register/value/C and this results in a short write where no data is written (ie. the value is ignored)

For read, the short option results in a read byte from the chip without specifying the register. Usually this will be the last register read from or written to, Thus for TMP102, a read byte followed by a read short will both return the same value

Please test with Arduino motor control system
