### PR TITLE
Adds solarized red as an alternative to OrangeRed links

### DIFF
--- a/public/static/css/boilerplate.css
+++ b/public/static/css/boilerplate.css
@@ -20,6 +20,7 @@ a.rascal.red {
     /* color: #9FD4FF; pale blue */
     /* color: #c6433c; logo red - difficult to read */
     color: OrangeRed;
+    /* color: #DC322F; solarized red */
 }
 
 [class^="icon-"],


### PR DESCRIPTION
This pull should only be for file public/static/css/boilerplate.css and the only change should be the addition of the commented out line

```
/* color: #DC322F; solarized red */
```

This is my suggestion for a better red for links

Please confirm that this is the only change in this pull. Thanks
