### PR TITLE
Minor changes to make it easier to run Rascal SW on a Mac

### DIFF
--- a/public/server.py
+++ b/public/server.py
@@ -1,6 +1,7 @@
 from flask import Flask, render_template, request
 from uwsgidecorators import *
-import os, pytronics, time
+import pytronics
+import os, time
 
 public = Flask(__name__)
 public.config['PROPAGATE_EXCEPTIONS'] = True
@@ -15,8 +16,11 @@ LIVE_PINS = ['LED', '2', '3', '4', '5', '8', '9', '10', '11', '12', '13']
 @public.route('/')
 @public.route('/index.html')
 def default_page():
-    with open('/etc/hostname', 'r') as f:
-        name = f.read().strip().capitalize()
+    try:
+        with open('/etc/hostname', 'r') as f:
+            name = f.read().strip().capitalize()
+    except:
+        name = 'Rascal'
     return render_template('/index.html', hostname=name, template_list = get_public_templates())
 
 def get_public_templates():


### PR DESCRIPTION
Two little changes:
1. Put import pytronics on a separate line, making it simpler to comment it out
2. Put the code to get the hostname for index.html within a try statement, allowing the default_page() function to run when /etc/hostname isn't present

See http://blog.hlh.co.uk/2012/02/04/setting-up-a-mac-as-a-rascal-development-system/
