### PR TITLE
Editor fix to send no-cache header with all POST

### DIFF
--- a/editor/__init__.py
+++ b/editor/__init__.py
@@ -10,6 +10,13 @@ CONFIG_FILE = '/var/www/editor/static/editor.conf'
 
 editor = Flask(__name__)
 
+# Include "no-cache" header in all POST responses
+@editor.after_request
+def add_no_cache(response):
+    if request.method == 'POST':
+        response.cache_control.no_cache = True
+    return response
+
 class User(UserMixin):
     def __init__(self, name, id, active=True):
         self.name = name


### PR DESCRIPTION
I just discovered that my iPad wasn't showing the correct files in the file tree and realised I'd forgotten to patch the editor
