### PR TITLE
Comment out Chrome fix for test-pins analog bar css transition

### DIFF
--- a/public/templates/test-pins.html
+++ b/public/templates/test-pins.html
@@ -39,7 +39,7 @@
         }
         .progress .bar {
             /* Workaround for Chrome redraw issue when bar shrinks */
-            -webkit-transform: translateZ(0.00001px);
+            /* -webkit-transform: translateZ(0.00001px); */
         }
     </style>
 </head>


### PR DESCRIPTION
Yesterday i tried using the latest Chrome beta but the "droppings" were still there when the A0 bar width was reduced so reverted to OS X release version (22.0.1229.94). Today they've disappeared again. The fix impairs the appearance of the bar in other browsers so I have commented it out.
