### PR TITLE
Updates to editor and about-docs

### DIFF
--- a/editor/static/js/editor-a.js
+++ b/editor/static/js/editor-a.js
@@ -102,12 +102,17 @@ function editorSetMode(ext) {
         Mode = ace.require("ace/mode/less").Mode;
         console.log('Mode less');
         break;
+    case 'md':
+        Mode = ace.require("ace/mode/markdown").Mode;
+        console.log('Mode markdown');
+        break;
     default:
         Mode = ace.require("ace/mode/text").Mode;
         console.log('Mode txt');
         break;
     }
     editor.getSession().setMode(new Mode());
+    editor.setReadOnly(ext === 'log');
 }
 
 function editorSetText(s, ext) {

--- a/editor/static/js/editor-cm.js
+++ b/editor/static/js/editor-cm.js
@@ -160,6 +160,9 @@ function editorSetMode(ext) {
     case 'less':
         mode = 'less';
         break;
+    case 'md':
+        mode = 'markdown';
+        break;
     case 'log':
         mode = 'log';
         break;
@@ -168,6 +171,7 @@ function editorSetMode(ext) {
     }
     // console.log('mode ' + mode);
     editor.setOption('mode', mode);
+    editor.setOption('readOnly', (ext === 'log'));
 }
 
 function editorSetText(s, ext) {

--- a/editor/templates/editor-a.html
+++ b/editor/templates/editor-a.html
@@ -23,6 +23,7 @@
     <script src="/editor/static/ace/build/src-noconflict/mode-text.js" type="text/javascript" charset="utf-8"></script>
     <script src="/editor/static/ace/build/src-noconflict/mode-xml.js" type="text/javascript" charset="utf-8"></script>
     <script src="/editor/static/ace/build/src-noconflict/mode-less.js" type="text/javascript" charset="utf-8"></script>
+    <script src="/editor/static/ace/build/src-noconflict/mode-markdown.js" type="text/javascript" charset="utf-8"></script>
     
     {% include "include/editor-scripts.html" %}
     <script src="/editor/static/js/jquery.filetree.js"></script>

--- a/editor/templates/editor-cm.html
+++ b/editor/templates/editor-cm.html
@@ -24,6 +24,7 @@
     <script src="/editor/static/codemirror/mode/htmlmixed/htmlmixed.js"></script>
     <script src="/editor/static/codemirror/mode/python/python.js"></script>
     <script src="/editor/static/codemirror/mode/less/less.js"></script>
+    <script src="/editor/static/codemirror/mode/markdown/markdown.js"></script>
     <script src="/editor/static/js/log.js"></script>
 
     <script src="/editor/static/codemirror/lib/util/searchcursor.js"></script>

--- a/public/templates/docs/about-docs.md
+++ b/public/templates/docs/about-docs.md
@@ -22,6 +22,33 @@ the following [Jinja2][jj2] variable which receives the formatted HTML:
 For example, you might want to edit `templates/documentation.html` change the default style.
 
 --
+Adding a Docs tab
+-----------
+As well as using Markdown to format a complete page, you can also add
+a **Docs** button to your templates. Clicking the Docs button slides out a documentation tab
+whose content is formatted using Markdown.
+For an example, see the [sprinkler](/sprinkler.html) demo.
+
+Adding a Docs tab to a new template involves three steps:
+
+1. When creating a new template, choose the option "HTML with Docs tab"
+2. View your new template in a browser and click its Docs tab
+3. Follow the instructions in the tab for creating the documentation template.
+
+To add a Docs tab to an existing HTML template, uncomment the line:
+
+    <!-- {% include "include/doc-tab.html" %} --> 
+
+by changing it to:
+
+    {% include "include/doc-tab.html" %} 
+
+If you want to add a Docs tab to an older template, create a new temporary template
+as in step 1, copy the line above into the corresponding position in your older template, then
+continue at step 2 with your template. The instructions for creating Docs tab
+content can also be found [here](/docs/default.md).
+
+--
 Markdown Cheat Sheet
 --------------------
 It is best to view this section both in the editor to see the Markdown source and in a web browser


### PR DESCRIPTION
Editor - make .log files read only, add markdown mode (applies to both CodeMirror and ACE)

about-docs.md - add section "Adding a Docs tab" 
